### PR TITLE
Convert float value of this.$element.innerHeight() to integer for pre…

### DIFF
--- a/js/iziModal.js
+++ b/js/iziModal.js
@@ -906,7 +906,7 @@
 
 	                // subistuido (contentHeight + this.headerHeight) por this.$element.innerHeight()
 	                // Se o modal é maior que a altura da janela ou 
-                	if ((contentHeight + this.headerHeight) > windowHeight || this.$element.innerHeight() < contentHeight || this.isFullscreen === true) {
+                	if ((contentHeight + this.headerHeight) > windowHeight || Math.ceil(this.$element.innerHeight()) < contentHeight || this.isFullscreen === true) {
 
 		                if( !$('html').hasClass(PLUGIN_NAME+'-isAttached') ){
 							$('html').addClass(PLUGIN_NAME+'-isAttached');


### PR DESCRIPTION
In some cases the value of this.$element.innerHeight() can be float instead of integer. Convert float value to integer for prevent this bug.

For example: 

recalculateLayout: function()

These values are obtained if the modal window size changed:

this.$element.innerHeight() == 540.9099731445312
contentHeight == 541 

In this case we get wrong condition: this.$element.innerHeight() < contentHeight in this line:

if ((contentHeight + this.headerHeight) > windowHeight || this.$element.innerHeight() < contentHeight || this.isFullscreen === true) {}
